### PR TITLE
Add site-scraping workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,14 @@ To learn more about Next.js, take a look at the following resources:
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
+
+## n8n Workflow
+
+A ready-to-import workflow is available at `n8n/workflows/scrape-latest-article.json`. It uses a Telegram bot to receive a message containing a website URL, scrapes the latest article on that site, summarizes it with the OpenAI node and sends the result back to Telegram.
+
+1. Import the JSON file in your n8n instance.
+2. Configure credentials for **Telegram** and **OpenAI**.
+3. Start the workflow and send a site URL (for example `https://www.goldmansachs.com/insights/`) to your bot.
+
+The workflow will respond with a short summary of the article's main points.
+

--- a/n8n/workflows/scrape-latest-article.json
+++ b/n8n/workflows/scrape-latest-article.json
@@ -1,0 +1,174 @@
+{
+  "name": "Scrape Latest Article and Summarize",
+  "nodes": [
+    {
+      "parameters": {
+        "updates": [
+          "message"
+        ]
+      },
+      "id": 1,
+      "name": "Telegram Trigger",
+      "type": "n8n-nodes-base.telegramTrigger",
+      "typeVersion": 1,
+      "position": [
+        -600,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "url": "={{$node[\"Telegram Trigger\"].json[\"message\"][\"text\"]}}"
+      },
+      "id": 2,
+      "name": "Fetch Site",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [
+        -400,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "functionCode": "const cheerio = require('cheerio');\nconst html = Buffer.from($node[\\"Fetch Site\\"].binary.data, 'base64').toString();\nconst $ = cheerio.load(html);\nconst link = $('article a').first().attr('href');\nreturn [{ json: { link } }];"
+      },
+      "id": 3,
+      "name": "Get Article Link",
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [
+        -200,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "url": "={{$json[\"link\"]}}"
+      },
+      "id": 4,
+      "name": "Fetch Article",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 1,
+      "position": [
+        0,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "html": "={{$node[\"Fetch Article\"].binary.data}}",
+        "cssSelector": "article"
+      },
+      "id": 5,
+      "name": "Extract Text",
+      "type": "n8n-nodes-base.htmlExtract",
+      "typeVersion": 1,
+      "position": [
+        200,
+        0
+      ]
+    },
+    {
+      "parameters": {
+        "prompt": "Summarize the following article in bullet points: {{$json[0]}}"
+      },
+      "id": 6,
+      "name": "OpenAI",
+      "type": "n8n-nodes-base.openAi",
+      "typeVersion": 1,
+      "position": [
+        400,
+        0
+      ],
+      "credentials": {
+        "openAiApi": "OpenAI Account"
+      }
+    },
+    {
+      "parameters": {
+        "chatId": "={{$node[\"Telegram Trigger\"].json[\"message\"][\"chat\"][\"id\"]}}",
+        "text": "={{$node[\"OpenAI\"].json[\"choices\"][0][\"text\"]}}"
+      },
+      "id": 7,
+      "name": "Send to Telegram",
+      "type": "n8n-nodes-base.telegram",
+      "typeVersion": 1,
+      "position": [
+        600,
+        0
+      ]
+    }
+  ],
+  "connections": {
+    "Telegram Trigger": {
+      "main": [
+        [
+          {
+            "node": "Fetch Site",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Site": {
+      "main": [
+        [
+          {
+            "node": "Get Article Link",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Get Article Link": {
+      "main": [
+        [
+          {
+            "node": "Fetch Article",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Fetch Article": {
+      "main": [
+        [
+          {
+            "node": "Extract Text",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Extract Text": {
+      "main": [
+        [
+          {
+            "node": "OpenAI",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "OpenAI": {
+      "main": [
+        [
+          {
+            "node": "Send to Telegram",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  },
+  "active": false,
+  "settings": {},
+  "versionId": "1"
+}


### PR DESCRIPTION
## Summary
- update README with new workflow usage
- change n8n workflow to fetch a site URL instead of RSS feed

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbe6b301c832c8563d145b3e814ae